### PR TITLE
fix: android APK release builds

### DIFF
--- a/ortto_flutter_sdk_android/android/build.gradle
+++ b/ortto_flutter_sdk_android/android/build.gradle
@@ -18,7 +18,7 @@ group 'com.ortto.androidsdk'
 version '1.0-SNAPSHOT'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Hey @scrummitch 👋 I hope you're doing well.

On android, it is currently not possible to build an app release APK:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ortto_flutter_sdk_android:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/Users/rodolphel/Dev/ra-campus-mobile/build/ortto_flutter_sdk_android/intermediates/merged_res/release/values/values.xml:2548: AAPT: error: resource android:attr/lStar not found.
```

I found that upgrading compile SDK version seems to fix the issue, so if there is no counter indication it would help a lot to merge this.

Let me know if that could work or if the issue should be adressed differently.

Thanks!