### PR TITLE
fixes issues with clearIdentity on ios

### DIFF
--- a/ortto_flutter_sdk/CHANGELOG.md
+++ b/ortto_flutter_sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+* Update ortto_flutter_sdk_ios to 0.3.4
+
 ## 0.4.1
 * Update ortto_flutter_android to 0.4.1
 * Updates Android SDK to v1.8.2

--- a/ortto_flutter_sdk/pubspec.yaml
+++ b/ortto_flutter_sdk/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   ortto_flutter_sdk_platform_interface: ^0.3.3
 #  ortto_flutter_sdk_platform_interface:
 #    path: ../ortto_flutter_sdk_platform_interface
-  ortto_flutter_sdk_ios: ^0.3.3
+  ortto_flutter_sdk_ios: ^0.3.4
 #  ortto_flutter_sdk_ios:
 #    path: ../ortto_flutter_sdk_ios
 

--- a/ortto_flutter_sdk/pubspec.yaml
+++ b/ortto_flutter_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk
 description: Ortto Flutter SDK
-version: 0.4.1
+version: 0.4.2
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 

--- a/ortto_flutter_sdk_ios/CHANGELOG.md
+++ b/ortto_flutter_sdk_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.4
+* Explicitly cast the platform channel's raw Map to a String-keyed dynamic-valued Map and handle a potentially null session ID with a default empty string. 
+
 ## 0.3.3
 * Updates iOS SDK to v1.6.2
 * Returns Future<WidgetResult> instead of void for showWidget(widgetId)

--- a/ortto_flutter_sdk_ios/lib/ortto_flutter_sdk_ios.dart
+++ b/ortto_flutter_sdk_ios/lib/ortto_flutter_sdk_ios.dart
@@ -96,9 +96,10 @@ class OrttoFlutterSdkIOS extends OrttoFlutterSdkPlatformInterface {
   }
 
   Future<IdentityResult> clearIdentity() async {
-    final Map<String, dynamic>? response = await methodChannel.invokeMethod('clearIdentity');
+    final response = await methodChannel.invokeMethod('clearIdentity');
     if (response != null) {
-      return IdentityResult.fromMap(response);
+      final Map<String, dynamic> responseMap = (response as Map).cast<String, dynamic>();
+      return IdentityResult.fromMap(responseMap);
     } else {
       throw Exception("Failed to clear identity");
     }

--- a/ortto_flutter_sdk_ios/pubspec.yaml
+++ b/ortto_flutter_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk_ios
 description: Ortto Flutter SDK iOS
-version: 0.3.3
+version: 0.3.4
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 

--- a/ortto_flutter_sdk_platform_interface/lib/src/models/identity_result.dart
+++ b/ortto_flutter_sdk_platform_interface/lib/src/models/identity_result.dart
@@ -5,7 +5,7 @@ class IdentityResult {
 
   factory IdentityResult.fromMap(Map<String, dynamic> map) {
     return IdentityResult(
-      sessionId: map['session_id'],
+      sessionId: map['session_id'] as String? ?? '',
     );
   }
 }


### PR DESCRIPTION
Fixes an issue with clearIdentity in the ios interface
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: type '_Map<Object?, Object?>' is not a subtype of type 'Map<String, dynamic>?' in type cast
#0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:334:41)
platform_channel.dart:334
<asynchronous suspension>
#1      OrttoFlutterSdkIOS.clearIdentity (package:ortto_flutter_sdk_ios/ortto_flutter_sdk_ios.dart:99:44)
ortto_flutter_sdk_ios.dart:99
<asynchronous suspension>
```