### PR TITLE
Fix notification extension fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
    1. In the application menu bar select File -> New -> Target
    2. Select Notification Service Extension
    3. Click Next
-   4. Name the extension `NotificationService`
+   4. Name the extension `NotificationServiceExtension`
    5. Click Finish
 4. In the `ios/Podfile` add the following
 ```ruby
-target 'NotificationExtension' do
+target 'NotificationServiceExtension' do
   use_frameworks!
-  pod 'OrttoPushMessagingFCM', '~> 1.5'
+  pod 'OrttoPushMessagingFCM', '1.8.4'
 end 
 ```
 5. Run `pod install --repo-update --project-directory=ios` in root project folder
@@ -118,19 +118,19 @@ import OrttoPushMessagingFCM
 
 class NotificationService: UNNotificationServiceExtension {
 
-    var contentHandler: ((UNNotificationContent) -> Void)?
-    var bestAttemptContent: UNMutableNotificationContent?
+    private var handledByOrtto = false
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        self.contentHandler = contentHandler
+        handledByOrtto = PushMessaging.shared.didReceive(request, withContentHandler: contentHandler)
 
-        let handled = PushMessaging.shared.didReceive(request, withContentHandler: contentHandler)        
+        if !handledByOrtto {
+            contentHandler(request.content)
+        }
     }
-    
+
     override func serviceExtensionTimeWillExpire() {
-    
-        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
+        if handledByOrtto {
+            PushMessaging.shared.serviceExtensionTimeWillExpire()
         }
     }
 }

--- a/example/ios/NotificationServiceExtension/NotificationService.swift
+++ b/example/ios/NotificationServiceExtension/NotificationService.swift
@@ -10,24 +10,20 @@ import OrttoPushMessagingFCM
 
 class NotificationService: UNNotificationServiceExtension {
 
-    var contentHandler: ((UNNotificationContent) -> Void)?
-    var bestAttemptContent: UNMutableNotificationContent?
+    private var handledByOrtto = false
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
 
-        self.contentHandler = contentHandler
+        handledByOrtto = PushMessaging.shared.didReceive(request, withContentHandler: contentHandler)
 
-        let handled = PushMessaging.shared.didReceive(request, withContentHandler: contentHandler)
-
-        if !handled {
-            print("Handled!")
+        if !handledByOrtto {
+            contentHandler(request.content)
         }
     }
 
     override func serviceExtensionTimeWillExpire() {
-        if let contentHandler = contentHandler,
-            let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
+        if handledByOrtto {
+            PushMessaging.shared.serviceExtensionTimeWillExpire()
         }
     }
 }

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -20,7 +20,7 @@ import UserNotifications
         Messaging.messaging().delegate = self
 
         // Set the iOS push notification click handler
-        // This is required in order for the Customer.io SDK to handle when a push is clicked.
+        // This is required in order for the Ortto SDK to handle when a push is clicked.
         UNUserNotificationCenter.current().delegate = self
 
         // Tells iOS to provide a push token, if one is available.
@@ -31,12 +31,13 @@ import UserNotifications
     }
     
     
-        func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-            
-            // push this ?
-            
-             Messaging.messaging().setAPNSToken(deviceToken, type: .unknown);
-         }
+        override func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {
+            super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+            Messaging.messaging().setAPNSToken(deviceToken, type: .unknown)
+        }
     
          // Called when a push notification is clicked.
          override func userNotificationCenter(


### PR DESCRIPTION
Fixes the iOS example so non-Ortto notifications, extension expiry, and APNs tokens are handled correctly.

## Changes

- Added fallback delivery of the original notification content when Ortto does not handle it.
- Updated extension expiry handling to call serviceExtensionTimeWillExpire on the Ortto SDK.
- Fixed the AppDelegate remote-token callback signature.
- Added the superclass token callback before forwarding the token to Firebase.
- Removed the unused bestAttemptContent lifecycle and inverted Handled log.
- Updated README target names, pod setup, and extension sample code.

## Verification

- Parsed both changed Swift files with the Swift compiler frontend.
- Passed git diff validation.