### PR TITLE
Fix iOS method channel completion contract

### DIFF
--- a/ortto_flutter_sdk_android/lib/ortto_flutter_sdk_android.dart
+++ b/ortto_flutter_sdk_android/lib/ortto_flutter_sdk_android.dart
@@ -82,7 +82,7 @@ class FlutterOrttoPushSdkAndroid extends OrttoFlutterSdkPlatformInterface {
 
   @override
   Future<void> processNextWidgetFromQueue() {
-    return methodChannel.invokeMethod('processNextWidgetInQueue');
+    return methodChannel.invokeMethod('processNextWidgetFromQueue');
   }
 
   @override

--- a/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
+++ b/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
@@ -63,4 +63,12 @@ void main() {
       'phone': '+61000000000',
     });
   });
+
+  test('processNextWidgetFromQueue uses the native method name', () async {
+    harness.respondWith(null);
+
+    await platform.processNextWidgetFromQueue();
+
+    expect(harness.singleCall.method, 'processNextWidgetFromQueue');
+  });
 }

--- a/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
+++ b/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
@@ -15,11 +15,12 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
+        case "getPlatformName":
+            result("iOS")
         case "initialize":
             initialize(call, result)
         case "initializeCapture":
-            initializeCapture(call)
-            result(nil)
+            initializeCapture(call, result)
         case "identify":
             identify(call, result)
         case "clearData":
@@ -29,15 +30,13 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
             dispatchPushRequest()
             result(nil)
         case "requestPermissions":
-            // TODO: implement requestPermissions
-            result(nil)
+            requestPermissions(result)
         case "registerDeviceToken":
-            registerDeviceToken(call)
+            registerDeviceToken(call, result)
         case "trackLinkClick":
             trackLinkClick(call, result)
         case "queueWidget":
-            queueWidget(call)
-            result(nil)
+            queueWidget(call, result)
         case "showWidget":
             showWidget(call, result)
         case "processNextWidgetFromQueue":
@@ -72,13 +71,27 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
         result(nil)
     }
 
-    private func initializeCapture(_ call: FlutterMethodCall) {
-        if let configMap = call.arguments as? [String:Any?] {
-            try? OrttoCapture.initialize(
-                dataSourceKey: (configMap["dataSourceKey"] as? String)!,
-                captureJsURL: URL(string: configMap["captureJsUrl"] as? String ?? ""),
-                apiHost: URL(string: configMap["apiHost"] as? String ?? "")
-            );
+    private func initializeCapture(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let configMap = call.arguments as? [String: Any?],
+              let dataSourceKey = configMap["dataSourceKey"] as? String,
+              !dataSourceKey.isEmpty else {
+            result(invalidArguments("initializeCapture requires a non-empty dataSourceKey"))
+            return
+        }
+
+        do {
+            try OrttoCapture.initialize(
+                dataSourceKey: dataSourceKey,
+                captureJsURL: url(from: configMap["captureJsUrl"]),
+                apiHost: url(from: configMap["apiHost"])
+            )
+            result(nil)
+        } catch {
+            result(FlutterError(
+                code: "CAPTURE_INITIALIZATION_ERROR",
+                message: error.localizedDescription,
+                details: String(describing: error)
+            ))
         }
     }
 
@@ -116,40 +129,49 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
         }
     }
 
-    private func queueWidget(_ call: FlutterMethodCall) {
-        guard let args = call.arguments as? [String:Any?] else {
+    private func queueWidget(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any?],
+              let widgetId = args["widgetId"] as? String,
+              !widgetId.isEmpty else {
+            result(invalidArguments("queueWidget requires a non-empty widgetId"))
             return
         }
 
-        if let widgetId = args["widgetId"] as? String {
-            OrttoCapture.shared.queueWidget(widgetId)
-        }
+        OrttoCapture.shared.queueWidget(widgetId)
+        result(nil)
     }
 
-    private func registerDeviceToken(_ call: FlutterMethodCall) {
-        guard let args = call.arguments as? [String:Any?] else {
+    private func registerDeviceToken(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any?],
+              let token = args["token"] as? String,
+              !token.isEmpty else {
+            result(invalidArguments("registerDeviceToken requires a non-empty token"))
             return
         }
 
-        if let token = args["token"] as? String {
-            PushMessaging.shared.registerDeviceToken(fcmToken: token)
-        }
+        PushMessaging.shared.registerDeviceToken(fcmToken: token)
+        result(nil)
     }
 
     private func trackLinkClick(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
-        guard let args = call.arguments as? [String:Any?] else {
+        guard let args = call.arguments as? [String: Any?] else {
+            result(invalidArguments("trackLinkClick requires an argument map"))
             return
         }
 
-        guard let link = args["link"] as? String else {
+        guard let link = args["link"] as? String, !link.isEmpty else {
+            result(invalidArguments("trackLinkClick requires a non-empty link"))
             return
         }
 
         Ortto.shared.trackLinkClick(link) {}
 
-        guard let uri = URL(string: link) else { return }
-        guard let components = URLComponents(string: uri.absoluteString) else { return }
-        guard let queryItems = components.queryItems else { return }
+        guard let uri = URL(string: link),
+              let components = URLComponents(string: uri.absoluteString) else {
+            result(FlutterError(code: "INVALID_LINK", message: "The link is malformed", details: link))
+            return
+        }
+        let queryItems = components.queryItems ?? []
 
         var linkUtm: [String: String] = queryItems.reduce(into: [String: String]()) { (result, item) in
             switch item.name {
@@ -167,6 +189,38 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
         }
 
         result(linkUtm)
+    }
+
+    private func requestPermissions(_ result: @escaping FlutterResult) {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                switch settings.authorizationStatus {
+                case .notDetermined:
+                    result("ASK")
+                case .denied:
+                    result("PREVIOUSLY_DENIED")
+                case .authorized, .provisional, .ephemeral:
+                    result("PREVIOUSLY_GRANTED")
+                @unknown default:
+                    result(FlutterError(
+                        code: "UNKNOWN_PERMISSION_STATUS",
+                        message: "iOS returned an unknown notification authorization status",
+                        details: settings.authorizationStatus.rawValue
+                    ))
+                }
+            }
+        }
+    }
+
+    private func invalidArguments(_ message: String) -> FlutterError {
+        FlutterError(code: "INVALID_ARGUMENTS", message: message, details: nil)
+    }
+
+    private func url(from value: Any?) -> URL? {
+        guard let string = value as? String, !string.isEmpty else {
+            return nil
+        }
+        return URL(string: string)
     }
 
     private func onMessageReceived(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
+++ b/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ortto_flutter_sdk_ios/ortto_flutter_sdk_ios.dart';
@@ -22,11 +24,13 @@ void main() {
   test('initialize sends the iOS channel contract', () async {
     harness.respondWith(null);
 
-    await platform.initialize(OrttoConfig(
-      'app-key',
-      'https://example.test',
-      shouldSkipNonExistingContacts: true,
-    ));
+    await platform.initialize(
+      OrttoConfig(
+        'app-key',
+        'https://example.test',
+        shouldSkipNonExistingContacts: true,
+      ),
+    );
 
     expect(harness.singleCall.method, 'initialize');
     expect(
@@ -38,15 +42,17 @@ void main() {
   test('identify sends every canonical identity field', () async {
     harness.respondWith(null);
 
-    await platform.identify(UserID(
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      acceptsGdpr: true,
-      contactId: 'contact-id',
-      email: 'ada@example.test',
-      externalId: 'external-id',
-      phone: '+61000000000',
-    ));
+    await platform.identify(
+      UserID(
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        acceptsGdpr: true,
+        contactId: 'contact-id',
+        email: 'ada@example.test',
+        externalId: 'external-id',
+        phone: '+61000000000',
+      ),
+    );
 
     expect(harness.singleCall.method, 'identify');
     expect(harness.singleCall.arguments, <String, dynamic>{
@@ -61,14 +67,74 @@ void main() {
   });
 
   test('identify propagates native failures', () async {
-    harness.respond((_) async => throw PlatformException(
-          code: 'IDENTIFY_ERROR',
-          message: 'native failure',
-        ));
+    harness.respond(
+      (_) async => throw PlatformException(
+        code: 'IDENTIFY_ERROR',
+        message: 'native failure',
+      ),
+    );
 
     await expectLater(
       platform.identify(UserID(email: 'ada@example.test')),
       throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test('getPlatformName returns the iOS native value', () async {
+    harness.respondWith('iOS');
+
+    await expectLater(platform.getPlatformName(), completion('iOS'));
+    expect(harness.singleCall.method, 'getPlatformName');
+  });
+
+  for (final permission in <PushPermission>[
+    PushPermission.ASK,
+    PushPermission.PREVIOUSLY_DENIED,
+    PushPermission.PREVIOUSLY_GRANTED,
+  ]) {
+    test('requestPermissions maps ${permission.name}', () async {
+      harness.respondWith(permission.name);
+
+      await expectLater(platform.requestPermissions(), completion(permission));
+      expect(harness.singleCall.method, 'requestPermissions');
+    });
+  }
+
+  test('registerDeviceToken sends a token and completes', () async {
+    harness.respondWith(null);
+
+    await MethodChannelHarness.expectCompletes(
+      platform.registerDeviceToken('device-token'),
+    );
+
+    expect(harness.singleCall.method, 'registerDeviceToken');
+    expect(harness.singleCall.arguments, <String, dynamic>{
+      'token': 'device-token',
+    });
+  });
+
+  test('registerDeviceToken propagates invalid argument failures', () async {
+    harness.respond(
+      (_) async => throw PlatformException(
+        code: 'INVALID_ARGUMENTS',
+        message: 'registerDeviceToken requires a non-empty token',
+      ),
+    );
+
+    await expectLater(
+      platform.registerDeviceToken(''),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test('registerDeviceToken fails fast when native never completes', () async {
+    harness.respond((_) => Completer<Object?>().future);
+
+    await expectLater(
+      MethodChannelHarness.expectCompletes(
+        platform.registerDeviceToken('device-token'),
+      ),
+      throwsA(isA<TimeoutException>()),
     );
   });
 }


### PR DESCRIPTION
Fixes iOS MethodChannel completion and permission behavior so public calls return exactly once with a useful result or error.

## Changes

- Added iOS getPlatformName support.
- Added iOS notification-state mapping for ASK, PREVIOUSLY_DENIED, and PREVIOUSLY_GRANTED.
- Fixed registerDeviceToken so successful calls complete their Future.
- Added structured errors for empty tokens and malformed arguments.
- Added capture initialization error propagation.
- Added widget queue argument validation.
- Fixed the Android processNextWidgetFromQueue method name.
- Updated synchronous iOS handlers so every branch completes once.
- Added permission, platform, token, error, method-name, and timeout tests.

## Verification

- Passed Android and iOS package analysis and tests.
- Parsed the complete Swift bridge successfully.

## Review order

- Review after PR 26 because it builds on the corrected identity and initialization contract.