### PR TITLE
Fix Flutter message handling semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   );
 
   Ortto.instance
-    .onbackgroundMessageReceived(message.toMap())
+    .onBackgroundMessageReceived(message.toMap())
     .then((handled) {
       return handled;
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,7 +70,10 @@ void main() async {
   // Handle foreground messages
   FirebaseMessaging.onMessage.listen((RemoteMessage message) {
     Ortto.instance
-      .onbackgroundMessageReceived(message.toMap())
+      .onBackgroundMessageReceived(
+        message.toMap(),
+        handleNotificationTrigger: true,
+      )
       .then((handled) {
         print("handled $handled");
         return handled;
@@ -92,7 +95,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
   // Pass the received background message to Ortto SDK
   Ortto.instance
-    .onbackgroundMessageReceived(message.toMap())
+    .onBackgroundMessageReceived(message.toMap())
     .then((handled) {
       return handled;
     });

--- a/ortto_flutter_sdk/CHANGELOG.md
+++ b/ortto_flutter_sdk/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 * **Breaking:** Remove the unused `allowAnonUsers` initialization argument. It was never forwarded to either native SDK; callers should omit it.
+* Rename `onbackgroundMessageReceived` to `onBackgroundMessageReceived`; the old spelling remains as a deprecated forwarding alias.
+* Prevent duplicate Android notifications by suppressing SDK display for background notification payloads while retaining display for data-only payloads.
 
 ## 0.6.3
 * Update ortto_flutter_sdk_android to 0.4.9

--- a/ortto_flutter_sdk/lib/ortto_flutter_sdk.dart
+++ b/ortto_flutter_sdk/lib/ortto_flutter_sdk.dart
@@ -84,8 +84,25 @@ class Ortto {
     return _platform.trackLinkClick(link);
   }
 
-  Future<bool> onbackgroundMessageReceived(Map<String, dynamic> message, {bool handleNotificationTrigger = true}) {
-    return _platform.onMessageReceived(message, handleNotificationTrigger: handleNotificationTrigger);
+  Future<bool> onBackgroundMessageReceived(
+    Map<String, dynamic> message, {
+    bool? handleNotificationTrigger,
+  }) {
+    return _platform.onMessageReceived(
+      message,
+      handleNotificationTrigger: handleNotificationTrigger ?? message['notification'] == null,
+    );
+  }
+
+  @Deprecated('Use onBackgroundMessageReceived instead.')
+  Future<bool> onbackgroundMessageReceived(
+    Map<String, dynamic> message, {
+    bool? handleNotificationTrigger,
+  }) {
+    return onBackgroundMessageReceived(
+      message,
+      handleNotificationTrigger: handleNotificationTrigger,
+    );
   }
 
   Future<IdentityResult> clearIdentity() {

--- a/ortto_flutter_sdk/test/ortto_flutter_sdk_test.dart
+++ b/ortto_flutter_sdk/test/ortto_flutter_sdk_test.dart
@@ -4,11 +4,15 @@ import 'package:ortto_flutter_sdk_platform_interface/ortto_flutter_sdk_platform_
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  final platform = RecordingPlatform();
+
+  setUpAll(() {
+    OrttoFlutterSdkPlatformInterface.instance = platform;
+  });
+
+  setUp(platform.reset);
 
   test('init delegates the complete configuration to the platform', () async {
-    final platform = RecordingPlatform();
-    OrttoFlutterSdkPlatformInterface.instance = platform;
-
     await Ortto.instance.init(
       appKey: 'app-key',
       endpoint: 'https://example.test',
@@ -21,10 +25,44 @@ void main() {
       'shouldSkipNonExistingContacts': true,
     });
   });
+
+  test('background notification payload suppresses duplicate display', () async {
+    await Ortto.instance.onBackgroundMessageReceived(<String, dynamic>{
+      'notification': <String, dynamic>{'title': 'Already displayed by FCM'},
+      'data': <String, dynamic>{'ortto': 'payload'},
+    });
+
+    expect(platform.handleNotificationTrigger, isFalse);
+  });
+
+  test('background data-only payload enables notification display', () async {
+    await Ortto.instance.onBackgroundMessageReceived(<String, dynamic>{
+      'data': <String, dynamic>{'ortto': 'payload'},
+    });
+
+    expect(platform.handleNotificationTrigger, isTrue);
+  });
+
+  test('foreground caller can explicitly enable notification display', () async {
+    await Ortto.instance.onBackgroundMessageReceived(
+      <String, dynamic>{
+        'notification': <String, dynamic>{'title': 'Foreground'},
+      },
+      handleNotificationTrigger: true,
+    );
+
+    expect(platform.handleNotificationTrigger, isTrue);
+  });
 }
 
 class RecordingPlatform extends OrttoFlutterSdkPlatformInterface {
   OrttoConfig? configuration;
+  bool? handleNotificationTrigger;
+
+  void reset() {
+    configuration = null;
+    handleNotificationTrigger = null;
+  }
 
   @override
   Future<void> initialize(OrttoConfig config) async {
@@ -60,6 +98,15 @@ class RecordingPlatform extends OrttoFlutterSdkPlatformInterface {
 
   @override
   Future<void> processNextWidgetFromQueue() async {}
+
+  @override
+  Future<bool> onMessageReceived(
+    Map<String, dynamic> message, {
+    bool handleNotificationTrigger = true,
+  }) async {
+    this.handleNotificationTrigger = handleNotificationTrigger;
+    return true;
+  }
 
   @override
   Future<String?> getPlatformName() async => 'test';

--- a/ortto_flutter_sdk_android/CHANGELOG.md
+++ b/ortto_flutter_sdk_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+* Use Android SDK 1.8.8 and forward notification display control to the native handler.
+
 ## 0.4.9
 * Fix onMessageReceived not returning result to Dart, causing background push handlers to hang and block subsequent messages
 * Use non-deprecated OrttoConfig constructor (3-param instead of 4-param)

--- a/ortto_flutter_sdk_android/android/build.gradle
+++ b/ortto_flutter_sdk_android/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.ortto:androidsdk:1.8.7"
+    implementation "com.ortto:androidsdk:1.8.8"
 //    implementation project(':ortto-android-sdk')
     implementation 'com.google.firebase:firebase-messaging-ktx:23.3.1'
 }

--- a/ortto_flutter_sdk_android/android/src/main/kotlin/com/ortto/messaging/flutter/OrttoFlutterSdkPlugin.kt
+++ b/ortto_flutter_sdk_android/android/src/main/kotlin/com/ortto/messaging/flutter/OrttoFlutterSdkPlugin.kt
@@ -241,6 +241,7 @@ class OrttoFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun onMessageReceived(call: MethodCall): Boolean {
         val message = call.argument<Map<String, Any>?>("message")
+        val handleNotificationTrigger = call.argument<Boolean>("handleNotificationTrigger") ?: true
         val context = applicationContext as Context
 
         // Inline transformation logic
@@ -273,7 +274,7 @@ class OrttoFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         val handler = PushNotificationHandler(remoteMessage)
 
-        return handler.handleMessage(context)
+        return handler.handleMessage(context, handleNotificationTrigger)
     }
 
     private fun clearIdentity(result: MethodChannel.Result) {

--- a/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
+++ b/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
@@ -71,4 +71,35 @@ void main() {
 
     expect(harness.singleCall.method, 'processNextWidgetFromQueue');
   });
+
+  for (final displayNotification in <bool>[true, false]) {
+    test('onMessageReceived forwards display=$displayNotification', () async {
+      harness.respondWith(true);
+      final message = <String, dynamic>{
+        'data': <String, dynamic>{'ortto': 'payload'},
+      };
+
+      final handled = await platform.onMessageReceived(
+        message,
+        handleNotificationTrigger: displayNotification,
+      );
+
+      expect(handled, isTrue);
+      expect(harness.singleCall.method, 'onMessageReceived');
+      expect(harness.singleCall.arguments, <String, dynamic>{
+        'message': message,
+        'handleNotificationTrigger': displayNotification,
+      });
+    });
+  }
+
+  test('onMessageReceived preserves a non-Ortto handled=false result', () async {
+    harness.respondWith(false);
+
+    final handled = await platform.onMessageReceived(<String, dynamic>{
+      'data': <String, dynamic>{'unrelated': 'payload'},
+    });
+
+    expect(handled, isFalse);
+  });
 }

--- a/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
+++ b/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
@@ -224,7 +224,7 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
     }
 
     private func onMessageReceived(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
-        result(true)
+        result(false)
     }
 
     private func processNextWidgetFromQueue() {

--- a/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
+++ b/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
@@ -137,4 +137,15 @@ void main() {
       throwsA(isA<TimeoutException>()),
     );
   });
+
+  test('onMessageReceived preserves the iOS handled=false result', () async {
+    harness.respondWith(false);
+
+    final handled = await platform.onMessageReceived(<String, dynamic>{
+      'data': <String, dynamic>{'unrelated': 'payload'},
+    });
+
+    expect(handled, isFalse);
+    expect(harness.singleCall.method, 'onMessageReceived');
+  });
 }


### PR DESCRIPTION
Corrects Flutter message handling so Android avoids duplicate notifications and both platforms report whether they actually handled a message.

## Changes

- Updated the Android bridge to use native Android SDK 1.8.8.
- Added forwarding of handleNotificationTrigger to the native Android handler.
- Added automatic display suppression for background notification payloads.
- Retained notification display for background data-only payloads.
- Added an explicit foreground display override.
- Updated the iOS bridge to return false for Firebase message maps it does not process.
- Renamed onbackgroundMessageReceived to onBackgroundMessageReceived.
- Added a deprecated forwarding alias for the old spelling.
- Updated the example app to use the corrected foreground and background behavior.
- Added payload, display, handled-result, and duplicate-prevention tests.

## Verification

- Passed analysis and tests in the Android, iOS, and top-level packages.
- Parsed the Swift bridge successfully.

## Review order

- Review after PR 27.
- Android compilation against 1.8.8 requires its Maven publication to complete.