### PR TITLE
Align link tracking across Flutter platforms

### DIFF
--- a/ortto_flutter_sdk/CHANGELOG.md
+++ b/ortto_flutter_sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Breaking:** Remove the unused `allowAnonUsers` initialization argument. It was never forwarded to either native SDK; callers should omit it.
 * Rename `onbackgroundMessageReceived` to `onBackgroundMessageReceived`; the old spelling remains as a deprecated forwarding alias.
 * Prevent duplicate Android notifications by suppressing SDK display for background notification payloads while retaining display for data-only payloads.
+* Align iOS and Android link UTM results and return structured errors for malformed links and tracking timeouts.
 
 ## 0.6.3
 * Update ortto_flutter_sdk_android to 0.4.9

--- a/ortto_flutter_sdk_android/android/src/main/kotlin/com/ortto/messaging/flutter/OrttoFlutterSdkPlugin.kt
+++ b/ortto_flutter_sdk_android/android/src/main/kotlin/com/ortto/messaging/flutter/OrttoFlutterSdkPlugin.kt
@@ -3,6 +3,9 @@ package com.ortto.messaging.flutter
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import java.lang.Exception
 import com.google.firebase.messaging.RemoteMessage
@@ -165,21 +168,57 @@ class OrttoFlutterSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun trackLinkClick(call: MethodCall, result: MethodChannel.Result) {
-        val link = call.argument<String>("link");
+        val link = call.argument<String>("link")
+        if (link.isNullOrBlank()) {
+            result.error("INVALID_ARGUMENTS", "trackLinkClick requires a non-empty link", null)
+            return
+        }
+
+        val uri = try {
+            Uri.parse(link)
+        } catch (error: RuntimeException) {
+            result.error("INVALID_LINK", "The link is malformed", error.message)
+            return
+        }
+
+        if (uri.scheme.isNullOrBlank()) {
+            result.error("INVALID_LINK", "The link is malformed", link)
+            return
+        }
+
+        val directUtm = LinkUtm.fromUri(uri)
+        if (uri.getQueryParameter("tracking_url") == null) {
+            result.success(linkUtmMap(directUtm))
+            return
+        }
+
+        val handler = Handler(Looper.getMainLooper())
+        var completed = false
+        val timeout = Runnable {
+            if (!completed) {
+                completed = true
+                result.error("TRACKING_ERROR", "Link tracking did not complete", link)
+            }
+        }
+        handler.postDelayed(timeout, 30_000)
 
         Ortto.instance().trackLinkClick(link) {
-            Log.d(tag, "trackLinkClick: $it")
-
-            val map = mapOf(
-                "utm_campaign" to it.campaign,
-                "utm_medium" to it.medium,
-                "utm_source" to it.source,
-                "utm_content" to it.content
-            )
-
-            result.success(map);
+            handler.post {
+                if (!completed) {
+                    completed = true
+                    handler.removeCallbacks(timeout)
+                    result.success(linkUtmMap(it))
+                }
+            }
         }
     }
+
+    private fun linkUtmMap(utm: LinkUtm): Map<String, String?> = mapOf(
+        "utm_campaign" to utm.campaign,
+        "utm_medium" to utm.medium,
+        "utm_source" to utm.source,
+        "utm_content" to utm.content
+    )
 
     private fun registerDeviceToken(call: MethodCall, result: MethodChannel.Result) {
         Ortto.instance().registerDeviceToken(call.argument<String>("token")) {

--- a/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
+++ b/ortto_flutter_sdk_android/test/ortto_flutter_sdk_android_test.dart
@@ -102,4 +102,36 @@ void main() {
 
     expect(handled, isFalse);
   });
+
+  test('trackLinkClick returns the shared LinkUtm shape', () async {
+    harness.respondWith(<String, dynamic>{
+      'utm_campaign': 'launch',
+      'utm_medium': 'push',
+      'utm_source': 'ortto',
+      'utm_content': null,
+    });
+
+    final utm = await platform.trackLinkClick(
+      'https://example.test?utm_campaign=launch',
+    );
+
+    expect(utm.campaign, 'launch');
+    expect(utm.medium, 'push');
+    expect(utm.source, 'ortto');
+    expect(utm.content, isNull);
+  });
+
+  test('trackLinkClick propagates malformed-link errors', () async {
+    harness.respond(
+      (_) async => throw PlatformException(
+        code: 'INVALID_LINK',
+        message: 'The link is malformed',
+      ),
+    );
+
+    await expectLater(
+      platform.trackLinkClick('not a URL'),
+      throwsA(isA<PlatformException>()),
+    );
+  });
 }

--- a/ortto_flutter_sdk_android/test/support/method_channel_harness.dart
+++ b/ortto_flutter_sdk_android/test/support/method_channel_harness.dart
@@ -17,6 +17,14 @@ class MethodChannelHarness {
     });
   }
 
+  void respond(Future<Object?> Function(MethodCall call) handler) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) {
+      calls.add(call);
+      return handler(call);
+    });
+  }
+
   void uninstall() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);

--- a/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
+++ b/ortto_flutter_sdk_ios/ios/Classes/OrttoFlutterSdkPlugin.swift
@@ -164,31 +164,74 @@ public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationC
             return
         }
 
-        Ortto.shared.trackLinkClick(link) {}
-
-        guard let uri = URL(string: link),
-              let components = URLComponents(string: uri.absoluteString) else {
+        guard let components = URLComponents(string: link),
+              components.scheme != nil else {
             result(FlutterError(code: "INVALID_LINK", message: "The link is malformed", details: link))
             return
         }
-        let queryItems = components.queryItems ?? []
 
-        var linkUtm: [String: String] = queryItems.reduce(into: [String: String]()) { (result, item) in
-            switch item.name {
-            case "utm_campaign":
-                result[item.name] = item.value
-            case "utm_source":
-                result[item.name] = item.value
-            case "utm_medium":
-                result[item.name] = item.value
-            case "utm_content":
-                result[item.name] = item.value
-            default:
-                result
+        let trackingValue = components.queryItems?.first(where: { $0.name == "tracking_url" })?.value
+        let utmSource = trackingValue.flatMap(decodeBase64URL) ?? link
+
+        let linkUtm = Ortto.shared.retrieveUtmParameters(utmSource) ?? LinkUtm([])
+
+        let response = linkUtmMap(linkUtm)
+        guard trackingValue != nil else {
+            result(response)
+            return
+        }
+
+        var completed = false
+        let complete: (Any) -> Void = { value in
+            DispatchQueue.main.async {
+                guard !completed else { return }
+                completed = true
+                result(value)
             }
         }
 
-        result(linkUtm)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+            guard !completed else { return }
+            completed = true
+            result(FlutterError(
+                code: "TRACKING_ERROR",
+                message: "Link tracking did not complete",
+                details: link
+            ))
+        }
+
+        Ortto.shared.trackLinkClick(link) {
+            complete(response)
+        }
+    }
+
+    private func decodeBase64URL(_ value: String) -> String? {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func linkUtmMap(_ utm: OrttoSDKCore.LinkUtm) -> [String: Any] {
+        [
+            "utm_campaign": flutterValue(utm.campaign),
+            "utm_medium": flutterValue(utm.medium),
+            "utm_source": flutterValue(utm.source),
+            "utm_content": flutterValue(utm.content)
+        ]
+    }
+
+    private func flutterValue(_ value: String?) -> Any {
+        if let value = value {
+            return value
+        }
+        return NSNull()
     }
 
     private func requestPermissions(_ result: @escaping FlutterResult) {

--- a/ortto_flutter_sdk_ios/lib/ortto_flutter_sdk_ios.dart
+++ b/ortto_flutter_sdk_ios/lib/ortto_flutter_sdk_ios.dart
@@ -63,7 +63,7 @@ class OrttoFlutterSdkIOS extends OrttoFlutterSdkPlatformInterface {
   Future<LinkUtm> trackLinkClick(String link) {
     return methodChannel.invokeMethod("trackLinkClick", {
       'link': link,
-    }).then((value) => LinkUtm.fromMap(value.cast<String, String>()));
+    }).then((value) => LinkUtm.fromMap(value.cast<String, dynamic>()));
   }
 
   @override

--- a/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
+++ b/ortto_flutter_sdk_ios/test/ortto_flutter_sdk_ios_test.dart
@@ -148,4 +148,80 @@ void main() {
     expect(handled, isFalse);
     expect(harness.singleCall.method, 'onMessageReceived');
   });
+
+  test('trackLinkClick returns the shared LinkUtm shape', () async {
+    harness.respondWith(<String, dynamic>{
+      'utm_campaign': 'launch',
+      'utm_medium': 'push',
+      'utm_source': 'ortto',
+      'utm_content': null,
+    });
+
+    final utm = await platform.trackLinkClick(
+      'https://example.test?utm_campaign=launch',
+    );
+
+    expect(utm.campaign, 'launch');
+    expect(utm.medium, 'push');
+    expect(utm.source, 'ortto');
+    expect(utm.content, isNull);
+  });
+
+  test('trackLinkClick accepts an encoded tracking link', () async {
+    harness.respondWith(<String, dynamic>{
+      'utm_campaign': 'launch',
+      'utm_medium': null,
+      'utm_source': null,
+      'utm_content': null,
+    });
+    const link =
+        'https://click.example.test?tracking_url=aHR0cHM6Ly9leGFtcGxlLnRlc3Q_dXRtX2NhbXBhaWduPWxhdW5jaA';
+
+    final utm = await platform.trackLinkClick(link);
+
+    expect(utm.campaign, 'launch');
+    expect(harness.singleCall.arguments, <String, dynamic>{'link': link});
+  });
+
+  test('trackLinkClick permits links with missing UTM values', () async {
+    harness.respondWith(<String, dynamic>{
+      'utm_campaign': null,
+      'utm_medium': null,
+      'utm_source': null,
+      'utm_content': null,
+    });
+
+    final utm = await platform.trackLinkClick('https://example.test/path');
+
+    expect(utm.campaign, isNull);
+    expect(utm.medium, isNull);
+  });
+
+  test('trackLinkClick propagates malformed-link errors', () async {
+    harness.respond(
+      (_) async => throw PlatformException(
+        code: 'INVALID_LINK',
+        message: 'The link is malformed',
+      ),
+    );
+
+    await expectLater(
+      platform.trackLinkClick('not a URL'),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test('trackLinkClick propagates native tracking failures', () async {
+    harness.respond(
+      (_) async => throw PlatformException(
+        code: 'TRACKING_ERROR',
+        message: 'Link tracking did not complete',
+      ),
+    );
+
+    await expectLater(
+      platform.trackLinkClick('https://example.test/tracked'),
+      throwsA(isA<PlatformException>()),
+    );
+  });
 }


### PR DESCRIPTION
Aligns link tracking across iOS and Android so encoded links, UTM values, failures, and completion all behave consistently.

## Changes

- Added decoding for embedded Base64URL tracking links on iOS.
- Updated iOS to pass the decoded URL through the native Ortto UTM decoder.
- Updated both platforms to return the same nullable LinkUtm map shape.
- Added support for direct UTM links and links with missing UTM fields.
- Added INVALID_ARGUMENTS errors for missing links.
- Added INVALID_LINK errors for malformed URLs.
- Added TRACKING_ERROR timeouts when native tracking never completes.
- Added one-shot completion guards so late callbacks cannot complete twice.
- Added encoded-link, direct-link, missing-value, malformed-link, native-error, and result-shape tests.

## Verification

- Passed Android and iOS package analysis and tests.
- Type-checked the Swift implementation in the later SPM simulator build.

## Review order

- Review after PR 28.