### PR TITLE
Add Flutter SPM and Firebase 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,80 @@ jobs:
 
       - name: Test
         run: flutter test
+
+  ios-build:
+    name: iOS ${{ matrix.dependency-manager }}
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        dependency-manager: [spm, cocoapods]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.0
+          channel: stable
+          cache: true
+
+      - name: Select dependency manager
+        run: |
+          if [ "${{ matrix.dependency-manager }}" = "spm" ]; then
+            flutter config --enable-swift-package-manager
+          else
+            flutter config --no-enable-swift-package-manager
+          fi
+
+      - name: Create clean iOS host app
+        run: |
+          flutter create \
+            --platforms=ios \
+            --org=com.ortto \
+            --project-name=ortto_ci \
+            "$RUNNER_TEMP/ortto_ci"
+          flutter pub add \
+            --directory="$RUNNER_TEMP/ortto_ci" \
+            "ortto_flutter_sdk@{path: $GITHUB_WORKSPACE/ortto_flutter_sdk}"
+          flutter pub add \
+            --directory="$RUNNER_TEMP/ortto_ci" \
+            "override:ortto_flutter_sdk_android@{path: $GITHUB_WORKSPACE/ortto_flutter_sdk_android}" \
+            "override:ortto_flutter_sdk_ios@{path: $GITHUB_WORKSPACE/ortto_flutter_sdk_ios}" \
+            "override:ortto_flutter_sdk_platform_interface@{path: $GITHUB_WORKSPACE/ortto_flutter_sdk_platform_interface}"
+          sed -i '' \
+            's/IPHONEOS_DEPLOYMENT_TARGET = 13.0/IPHONEOS_DEPLOYMENT_TARGET = 15.0/g' \
+            "$RUNNER_TEMP/ortto_ci/ios/Runner.xcodeproj/project.pbxproj"
+          sed -i '' \
+            "s/platform :ios, '13.0'/platform :ios, '15.0'/" \
+            "$RUNNER_TEMP/ortto_ci/ios/Podfile"
+
+      - name: Build iOS simulator app
+        working-directory: ${{ runner.temp }}/ortto_ci
+        run: flutter build ios --simulator --debug
+
+      - name: Verify Firebase Apple SDK 12
+        working-directory: ${{ runner.temp }}/ortto_ci
+        run: |
+          if [ "${{ matrix.dependency-manager }}" = "spm" ]; then
+            resolved=$(find ios -name Package.resolved | head -1)
+            ruby -rjson -e '
+              pins = JSON.parse(File.read(ARGV.fetch(0))).fetch("pins")
+              versions = pins
+                .select { |pin| pin["identity"] == "firebase-ios-sdk" }
+                .map { |pin| pin.fetch("state").fetch("version") }
+                .uniq
+              abort "Expected one Firebase Apple 12.x version, got #{versions}" unless
+                versions.length == 1 && versions.first.start_with?("12.")
+              puts "Firebase Apple SDK #{versions.first}"
+            ' "$resolved"
+          else
+            versions=$(grep -E '^  - Firebase[^ ]* \([0-9]+\.[0-9]+\.[0-9]+\)' ios/Podfile.lock \
+              | sed -E 's/.*\(([0-9]+\.[0-9]+\.[0-9]+).*/\1/' \
+              | sort -u)
+            if [ "$(printf '%s\n' "$versions" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ] \
+              || [[ "$versions" != 12.* ]]; then
+              echo "Expected one Firebase Apple 12.x version, got: $versions"
+              exit 1
+            fi
+            echo "Firebase Apple SDK $versions"
+          fi

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 ```
 
 
+## iOS dependency management
+
+Flutter 3.44 and later can integrate the iOS plugin with Swift Package Manager. Enable Flutter's SPM support before building:
+
+```shell
+flutter config --enable-swift-package-manager
+flutter clean
+flutter pub get
+```
+
+The plugin resolves Ortto iOS SDK `1.10.x` or newer up to, but excluding, `2.0.0`. Projects that keep CocoaPods enabled continue to use the podspec fallback pinned to Ortto iOS SDK `1.9.1`.
+
 ## iOS Background Notifications
 
 1. Open the `ios/Runner.xcworkspace` workspace folder in Xcode

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,7 +42,7 @@ target 'NotificationServiceExtension' do
   use_frameworks!
   # use_modular_headers!
 
-  pod 'OrttoPushMessagingFCM', '1.8.4'
+  pod 'OrttoPushMessagingFCM', '1.9.1'
   # pod 'OrttoPushMessagingFCM', :path => '../../../ios-sdk'
 
   # The below line must be commented out after xcode~13

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  firebase_messaging: ^15.2.10
+  firebase_messaging: ^16.0.0
   flutter:
     sdk: flutter
   ortto_flutter_sdk: ^0.6.3

--- a/example/pubspec_overrides.yaml
+++ b/example/pubspec_overrides.yaml
@@ -1,0 +1,9 @@
+dependency_overrides:
+  ortto_flutter_sdk:
+    path: ../ortto_flutter_sdk
+  ortto_flutter_sdk_android:
+    path: ../ortto_flutter_sdk_android
+  ortto_flutter_sdk_ios:
+    path: ../ortto_flutter_sdk_ios
+  ortto_flutter_sdk_platform_interface:
+    path: ../ortto_flutter_sdk_platform_interface

--- a/ortto_flutter_sdk/CHANGELOG.md
+++ b/ortto_flutter_sdk/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Rename `onbackgroundMessageReceived` to `onBackgroundMessageReceived`; the old spelling remains as a deprecated forwarding alias.
 * Prevent duplicate Android notifications by suppressing SDK display for background notification payloads while retaining display for data-only payloads.
 * Align iOS and Android link UTM results and return structured errors for malformed links and tracking timeouts.
+* Add Flutter 3.44 Swift Package Manager support, Firebase 12 compatibility, and a CocoaPods fallback on Ortto iOS 1.9.1.
 
 ## 0.6.3
 * Update ortto_flutter_sdk_android to 0.4.9

--- a/ortto_flutter_sdk/pubspec.yaml
+++ b/ortto_flutter_sdk/pubspec.yaml
@@ -17,8 +17,8 @@ flutter:
         default_package: ortto_flutter_sdk_ios
 
 dependencies:
-  firebase_core: ^3.15.2
-  firebase_messaging: ^15.2.10
+  firebase_core: ^4.0.0
+  firebase_messaging: ^16.0.0
   flutter:
     sdk: flutter
   ortto_flutter_sdk_android: ^0.4.9

--- a/ortto_flutter_sdk_ios/CHANGELOG.md
+++ b/ortto_flutter_sdk_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+* Add Swift Package Manager support with Ortto iOS `>=1.10.0 <2.0.0`.
+* Pin the CocoaPods fallback to Ortto iOS 1.9.1 and Firebase Apple 12.
+
 ## 0.6.2
 * Update Ortto iOS SDK to v1.8.4
 

--- a/ortto_flutter_sdk_ios/README.md
+++ b/ortto_flutter_sdk_ios/README.md
@@ -1,7 +1,9 @@
-# Ortto Flutter SDK iOS 
+# Ortto Flutter SDK iOS
 
-A android API for the [Ortto Flutter](https://github.com/autopilot3/ortto-flutter-sdk) SDK.
+The iOS implementation for the [Ortto Flutter SDK](https://github.com/autopilot3/ortto-flutter-sdk).
 
-```
+```shell
 flutter pub add ortto_flutter_sdk_ios
 ```
+
+Flutter 3.44 and later can integrate this plugin with Swift Package Manager. CocoaPods remains available as a fallback.

--- a/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios.podspec
+++ b/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license           = { :type => 'MIT', :file => 'LICENSE' }
   s.author            = { 'Ortto.com Team' => 'help@ortto.com' }
   s.source            = { :git => 'https://github.com/autopilot3/ortto-push-ios-sdk.git', :tag => s.version.to_s }
-  s.source_files      = 'Classes/**/*'
+  s.source_files      = 'ortto_flutter_sdk_ios/Sources/ortto_flutter_sdk_ios/**/*'
   s.documentation_url = 'https://help.ortto.com/developer/latest/developer-guide/push-sdks/'
   s.ios.deployment_target = '15.0'
   s.platform          = :ios, '15.0'
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   # Dependencies
   s.dependency 'Flutter'
-  s.dependency 'OrttoSDKCore', '1.8.4'
-  s.dependency 'OrttoInAppNotifications', '1.8.4'
-  s.dependency 'OrttoPushMessagingFCM', '1.8.4'
+  s.dependency 'OrttoSDKCore', '1.9.1'
+  s.dependency 'OrttoInAppNotifications', '1.9.1'
+  s.dependency 'OrttoPushMessagingFCM', '1.9.1'
 end

--- a/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios/Package.swift
+++ b/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "ortto_flutter_sdk_ios",
+    platforms: [
+        .iOS("15.0")
+    ],
+    products: [
+        .library(
+            name: "ortto-flutter-sdk-ios",
+            targets: ["ortto_flutter_sdk_ios"]
+        )
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
+        .package(
+            url: "https://github.com/autopilot3/ortto-push-ios-sdk.git",
+            "1.10.0"..<"2.0.0"
+        )
+    ],
+    targets: [
+        .target(
+            name: "ortto_flutter_sdk_ios",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
+                .product(name: "OrttoSDKCore", package: "ortto-push-ios-sdk"),
+                .product(name: "OrttoInAppNotifications", package: "ortto-push-ios-sdk"),
+                .product(name: "OrttoPushMessaging", package: "ortto-push-ios-sdk"),
+                .product(name: "OrttoPushMessagingFCM", package: "ortto-push-ios-sdk")
+            ]
+        )
+    ]
+)

--- a/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios/Sources/ortto_flutter_sdk_ios/OrttoFlutterSdkPlugin.swift
+++ b/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios/Sources/ortto_flutter_sdk_ios/OrttoFlutterSdkPlugin.swift
@@ -4,7 +4,6 @@ import OrttoSDKCore
 import OrttoPushMessagingFCM
 import OrttoInAppNotifications
 import OrttoPushMessaging
-import FirebaseMessaging
 
 public class OrttoFlutterSdkPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate {
     public static func register(with registrar: FlutterPluginRegistrar) {


### PR DESCRIPTION
Adds Flutter 3.44 Swift Package Manager support while upgrading FlutterFire to Firebase Apple 12 and retaining a CocoaPods fallback.

## Changes

- Added a Package.swift for the iOS Flutter plugin.
- Added the FlutterFramework package dependency.
- Added Ortto iOS SDK support from 1.10.0 up to but excluding 2.0.0.
- Moved the Swift bridge into one source location shared by SPM and CocoaPods.
- Updated firebase_core to 4.x and firebase_messaging to 16.x.
- Removed the unused FirebaseMessaging Swift import.
- Updated the CocoaPods fallback to Ortto iOS SDK 1.9.1.
- Added Flutter 3.44 SPM and CocoaPods simulator CI jobs.
- Added CI assertions that exactly one Firebase Apple 12.x version resolves.
- Updated integration documentation for both dependency managers.

## Verification

- Passed Flutter analysis and tests.
- Passed a Flutter 3.44 SPM simulator build.
- Resolved Ortto iOS SDK 1.10.0 and Firebase Apple SDK 12.15.0.
- Validated the Swift package manifest and workflow YAML.

## Review order

- Review after PR 29.
- The CocoaPods fallback build requires Ortto iOS 1.9.1 to be published.