### PR TITLE
Prepare Flutter SDK 0.7.0 release

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,42 @@
+# Migrating to 0.7.0
+
+## Initialization
+
+Remove `allowAnonUsers` from calls to `Ortto.instance.init`. The option was never forwarded to either native SDK, so removing it does not change native behavior.
+
+```dart
+await Ortto.instance.init(
+  appKey: appKey,
+  endpoint: endpoint,
+  shouldSkipNonExistingContacts: true,
+);
+```
+
+## Background messages
+
+Rename `onbackgroundMessageReceived` to `onBackgroundMessageReceived`. The old spelling remains as a deprecated forwarding alias for this release.
+
+For Android background delivery, notification payloads now suppress a second SDK-posted notification automatically. Data-only payloads still allow the SDK to display the notification. Foreground handlers can override this explicitly:
+
+```dart
+await Ortto.instance.onBackgroundMessageReceived(
+  message.toMap(),
+  handleNotificationTrigger: true,
+);
+```
+
+## Firebase 12
+
+Version 0.7.0 uses `firebase_core` 4.x and `firebase_messaging` 16.x. These packages resolve Firebase Apple SDK 12.x. Review the FlutterFire migration guidance if the application uses Firebase APIs outside this SDK.
+
+## Swift Package Manager
+
+Flutter 3.44 and later can integrate the iOS plugin with Swift Package Manager:
+
+```shell
+flutter config --enable-swift-package-manager
+flutter clean
+flutter pub get
+```
+
+SPM resolves Ortto iOS SDK `>=1.10.0 <2.0.0`. CocoaPods remains available as a fallback and is pinned to Ortto iOS SDK 1.9.1.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   firebase_messaging: ^16.0.0
   flutter:
     sdk: flutter
-  ortto_flutter_sdk: ^0.6.3
+  ortto_flutter_sdk: ^0.7.0
 #  ortto_flutter_sdk:
 #    path: ../ortto_flutter_sdk
   uuid: ^3.0.6

--- a/ortto_flutter_sdk/CHANGELOG.md
+++ b/ortto_flutter_sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.7.0
 
 * **Breaking:** Remove the unused `allowAnonUsers` initialization argument. It was never forwarded to either native SDK; callers should omit it.
 * Rename `onbackgroundMessageReceived` to `onBackgroundMessageReceived`; the old spelling remains as a deprecated forwarding alias.

--- a/ortto_flutter_sdk/pubspec.yaml
+++ b/ortto_flutter_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk
 description: Ortto Flutter SDK
-version: 0.6.3
+version: 0.7.0
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 
@@ -21,13 +21,13 @@ dependencies:
   firebase_messaging: ^16.0.0
   flutter:
     sdk: flutter
-  ortto_flutter_sdk_android: ^0.4.9
+  ortto_flutter_sdk_android: ^0.5.0
 #  ortto_flutter_sdk_android:
 #    path: ../ortto_flutter_sdk_android
-  ortto_flutter_sdk_platform_interface: ^0.4.0
+  ortto_flutter_sdk_platform_interface: ^0.5.0
 #  ortto_flutter_sdk_platform_interface:
 #    path: ../ortto_flutter_sdk_platform_interface
-  ortto_flutter_sdk_ios: ^0.6.2
+  ortto_flutter_sdk_ios: ^0.7.0
 #  ortto_flutter_sdk_ios:
 #    path: ../ortto_flutter_sdk_ios
 

--- a/ortto_flutter_sdk_android/CHANGELOG.md
+++ b/ortto_flutter_sdk_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next
+## 0.5.0
 * Use Android SDK 1.8.8 and forward notification display control to the native handler.
 
 ## 0.4.9

--- a/ortto_flutter_sdk_android/pubspec.yaml
+++ b/ortto_flutter_sdk_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk_android
 description: Ortto Flutter SDK Android
-version: 0.4.9
+version: 0.5.0
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  ortto_flutter_sdk_platform_interface: ^0.4.0
+  ortto_flutter_sdk_platform_interface: ^0.5.0
 #  ortto_flutter_sdk_platform_interface:
 #    path: ../ortto_flutter_sdk_platform_interface
 

--- a/ortto_flutter_sdk_ios/CHANGELOG.md
+++ b/ortto_flutter_sdk_ios/CHANGELOG.md
@@ -1,4 +1,5 @@
-## Next
+## 0.7.0
+* Fix identity serialization, native error propagation, permissions, token completion, platform naming, and link tracking.
 * Add Swift Package Manager support with Ortto iOS `>=1.10.0 <2.0.0`.
 * Pin the CocoaPods fallback to Ortto iOS 1.9.1 and Firebase Apple 12.
 

--- a/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios.podspec
+++ b/ortto_flutter_sdk_ios/ios/ortto_flutter_sdk_ios.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = 'ortto_flutter_sdk_ios'
-  s.version           = '1.8.4'
+  s.version           = '0.7.0'
   s.summary           = 'OrttoSDK'
   s.homepage          = 'https://github.com/autopilot3/ortto-push-ios-sdk'
   s.license           = { :type => 'MIT', :file => 'LICENSE' }

--- a/ortto_flutter_sdk_ios/pubspec.yaml
+++ b/ortto_flutter_sdk_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk_ios
 description: Ortto Flutter SDK iOS
-version: 0.6.2
+version: 0.7.0
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  ortto_flutter_sdk_platform_interface: ^0.4.0
+  ortto_flutter_sdk_platform_interface: ^0.5.0
 #  ortto_flutter_sdk_platform_interface:
 #    path: ../ortto_flutter_sdk_platform_interface
 

--- a/ortto_flutter_sdk_platform_interface/CHANGELOG.md
+++ b/ortto_flutter_sdk_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+* Standardize identity serialization keys across Dart, iOS, and Android.
+* Remove the unused `allowAnonUsers` configuration field.
+* Add method-channel contract and timeout test utilities.
+
 ## 0.4.0
 * Return Future<IdentityResult> for clearIdentity() and handle failures better for showWidget()
 

--- a/ortto_flutter_sdk_platform_interface/pubspec.yaml
+++ b/ortto_flutter_sdk_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ortto_flutter_sdk_platform_interface
 description: Ortto Flutter SDK Platform Interface
-version: 0.4.0
+version: 0.5.0
 homepage: https://ortto.com/
 repository: https://github.com/autopilot3/ortto-flutter-sdk
 


### PR DESCRIPTION
Prepares the federated Flutter packages, documentation, and validation results needed for the final 0.7.0 release.

## Changes

- Updated ortto_flutter_sdk_platform_interface to 0.5.0.
- Updated ortto_flutter_sdk_android to 0.5.0.
- Updated ortto_flutter_sdk_ios to 0.7.0.
- Updated ortto_flutter_sdk to 0.7.0.
- Updated every federated dependency constraint for publication order.
- Added release changelogs for all changed packages.
- Added migration guidance for allowAnonUsers removal.
- Added migration guidance for onBackgroundMessageReceived.
- Added Firebase 12 and Swift Package Manager migration guidance.
- Updated the CocoaPods plugin version to match the Flutter iOS package.

## Verification completed

- Passed flutter analyze in all four packages.
- Passed flutter test in all four packages.
- Completed publish dry runs for all four packages with zero warnings.
- Inherited a successful Flutter 3.44 SPM simulator build using Ortto iOS 1.10.0 and Firebase Apple 12.15.0.

## Required before merge

- Merge the prerequisite PR stack and publishing workflow PR.
- Enable organization-level GitHub Actions.
- Publish and verify iOS CocoaPods 1.9.1.
- Publish and verify Android SDK 1.8.8.
- Run Android and CocoaPods fallback compilation.
- Complete physical-device smoke tests.
- Rerun publication dry runs from final main.

This PR remains a draft until every release blocker is complete.